### PR TITLE
Switch to alpine:edge base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
 # DOCKER-VERSION 1.0.1
 # VERSION        0.5
 
-FROM debian:jessie
+FROM    alpine:edge
 MAINTAINER Justin Plock <justin@plock.net>
 
-RUN apt-get update && apt-get install -y openjdk-7-jre-headless wget
-RUN wget -q -O - http://apache.mirrors.pair.com/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz | tar -xzf - -C /opt \
-    && mv /opt/zookeeper-3.4.6 /opt/zookeeper \
-    && cp /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg \
-    && mkdir -p /tmp/zookeeper
+ENV     MIRROR  http://apache.mirrors.pair.com/
+ENV     VERSION 3.4.6
+RUN     apk --update add openjdk7-jre wget bash
+RUN     mkdir /opt && \
+            wget -q -O - $MIRROR/zookeeper/zookeeper-$VERSION/zookeeper-$VERSION.tar.gz | \
+            tar -xzf - -C /opt && \
+            mv /opt/zookeeper-$VERSION /opt/zookeeper && \
+            cp /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg && \
+            mkdir -p /tmp/zookeeper
 
-ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+ENV     JAVA_HOME /usr/lib/jvm/java-1.7-openjdk
 
 EXPOSE 2181 2888 3888
 


### PR DESCRIPTION
Not sure if you're interested in this, but I thought I'd try.

Changing the base image to `alpine:edge` reduces the image size to 163M (from 342M), so less than half the size!