### PR TITLE
Update README version for 3.4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ docker-zookeeper
 
 Builds a docker image for Zookeeper.
 
-```docker build -t <user>/zookeeper:3.4.6 .```
+```docker build -t <user>/zookeeper:3.4.7 .```


### PR DESCRIPTION
The Dockerfile now uses 3.4.7, so the README should have that too.